### PR TITLE
Add clickable links to contact information

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,8 +98,8 @@
     <div class="header">
         <h1>JAMES GREENIA</h1>
         <div class="contact">
-            Orlando, FL | jgreenia@jandraisolutions.com | linkedin.com/in/james-greenia-535799149<br>
-            GitHub: github.com/Turtles-AI-Lab | Available: Remote or On-site
+            Orlando, FL | <a href="mailto:jgreenia@jandraisolutions.com">jgreenia@jandraisolutions.com</a> | <a href="https://linkedin.com/in/james-greenia-535799149" target="_blank" rel="noopener noreferrer">linkedin.com/in/james-greenia-535799149</a><br>
+            GitHub: <a href="https://github.com/Turtles-AI-Lab" target="_blank" rel="noopener noreferrer">github.com/Turtles-AI-Lab</a> | Available: Remote or On-site
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Makes email, LinkedIn, and GitHub URLs clickable
- Improves usability for recruiters
- Adds proper security attributes (rel="noopener noreferrer")

## Changes
- Email: Added `mailto:` link
- LinkedIn: Made URL clickable with target="_blank"
- GitHub: Made URL clickable with target="_blank"
- Added security attributes to external links

## Related Issue
Addresses #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)